### PR TITLE
Add LUFA boards to Tools>Board menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ Alternatively, there are instructions for [manual installation].
     $ git clone --recursive https://github.com/Palatis/Arduino-Lufa.git LUFA
     ```
 
-4. Activate LUFA (more on this below)
+4. Install LUFA boards (more on this below)
 
     ```
-    $ ./LUFA/activate.py
+    $ ./LUFA/install.py
     ```
 
 5. Done! Proceed with the steps below to try out Arduino-Lufa
@@ -49,7 +49,9 @@ Alternatively, there are instructions for [manual installation].
 
 ## First run and use
 
-To test Arduino-Lufa, open the LUFA_DualVirtualSerial example and click __Verify__. (See Note on __Upload__ below)
+To test Arduino-Lufa, open the LUFA_DualVirtualSerial example, select your board type from
+the `Tools > Board > Arduino LUFA AVR Boards` submenu and click __Verify__. 
+(See Note on __Upload__ below)
 
 <img src="docs/open_example.png" height="250"
 alt="File -> Examples -> Examples for any board -> LUFA -> LUFA_DualVirtualSerial"
@@ -79,18 +81,32 @@ This is not permanent, however. To go back to the original state, upload a sketc
 
 ## Deactivating Arduino-Lufa
 
-If you need to compile sketches that use the Arduino Core USB Stack, you'll have to deactivate LUFA like so:
+If you need to compile sketches that use the Arduino Core USB Stack, you'll need to select the board type from
+the `Tools > Board > Arduino AVR Boards` submenu.
+
+If you used the `activate.py` script to change the main core files (legacy method), then you'll have to deactivate
+LUFA like so:
 
 ```
 $ ./<arduino_install_path>/libraries/LUFA/deactivate.py
 ```
 
-If you work with a lot of different boards and find switching tedious, it is recommended to copy your Arduino IDE into a new directory called something like `Arduino-LUFA`, and activiting LUFA only in that installation. To avoid confusion, you can then also delete `libraries/LUFA` from the original install, but make sure to run `deactivate.py` first!
+Uninstalling the LUFA AVR Boards can be done like so: 
+
+```
+$ ./<arduino_install_path>/libraries/LUFA/uninstall.py
+```
+
+or simply by deleting the `./<arduino_install_path>/hardware/arduino-LUFA` folder.
+
+If you work with a lot of different boards and find switching tedious, it is recommended to use the `install.py` script
+so that you can always switch to and from LUFA by selecting the Arduino board from the relevant submenu.
 
 ## Credits
 * Victor Tseng: palatis _AT_ gmail _DOT_ com (Original Author)
 * Daniel Korgel (Contributor)
 * Felix Uhl (Contributor)
+* CrazyRedMachine (Contributor)
 * Arduino: http://arduino.cc
 * LUFA: http://www.fourwalledcubicle.com/LUFA.php
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Alternatively, there are instructions for [manual installation].
 
 To test Arduino-Lufa, open the LUFA_DualVirtualSerial example, select your board type from
 the `Tools > Board > Arduino LUFA AVR Boards` submenu and click __Verify__. 
-(**Note**: some of the AVR boards are untested and might prove to be incompatible, 
-please open an issue if you run into this case. Also see Note on __Upload__ below)
+(**Note**: only atmega32u4 based boards are marked as compatible and will appear, if you 
+are using another board which should be compatible please open an issue. Also see Note on __Upload__ below)
 
 <img src="docs/open_example.png" height="250"
 alt="File -> Examples -> Examples for any board -> LUFA -> LUFA_DualVirtualSerial"

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ Alternatively, there are instructions for [manual installation].
 
 To test Arduino-Lufa, open the LUFA_DualVirtualSerial example, select your board type from
 the `Tools > Board > Arduino LUFA AVR Boards` submenu and click __Verify__. 
-(See Note on __Upload__ below)
+(**Note**: some of the AVR boards are untested and might prove to be incompatible, 
+please open an issue if you run into this case. Also see Note on __Upload__ below)
 
 <img src="docs/open_example.png" height="250"
 alt="File -> Examples -> Examples for any board -> LUFA -> LUFA_DualVirtualSerial"

--- a/activate.py
+++ b/activate.py
@@ -1,4 +1,4 @@
-#!python3
+#!/usr/bin/env python3
 """
 Script to activate LUFA for Arduino.
 When LUFA is active, Arduinos USB stack is deactivated and cannot be compiled against.
@@ -171,7 +171,7 @@ def unhide_section_in_file(path):
 #--------------------------#
 # Arudino version checking #
 #--------------------------#
-SUPPORTED_ARDUINO_IDE_VERSIONS = ['1.8.2', '1.8.3', '1.8.13']
+SUPPORTED_ARDUINO_IDE_VERSIONS = ['1.8.2', '1.8.3', '1.8.12', '1.8.13']
 
 def get_arduino_ide_version():
     """Determine Arduino IDE version"""

--- a/activate.py
+++ b/activate.py
@@ -226,11 +226,25 @@ def update_platform():
         print(line)
 
 def update_boards():
+    unsupported = []
     myfile = fileinput.FileInput(absolute_path(os.path.join(ARDUINO_LUFA_AVR_DIR, "boards.txt")), inplace=True)
 
+    #first pass: append (LUFA) to names and check for unsupported boards
     for line in myfile:
         line = re.sub(r"name=(.*)", r"name=\1 (LUFA)", line.rstrip())
+
+        if "build.mcu=" in line and not "atmega32u4" in line:
+             unsup = line.split(".",1)[0]
+             unsupported.append(unsup)
         print(line)
+
+    #second pass: filter unsupported boards
+    myfile = fileinput.FileInput(absolute_path(os.path.join(ARDUINO_LUFA_AVR_DIR, "boards.txt")), inplace=True)
+    for line in myfile:
+        if line.split(".",1)[0] in unsupported:
+            line = "#" + line
+            line = re.sub(r"LUFA", r"LUFA not supported", line.rstrip())
+        print(line.rstrip())
 
 def activate():
     """Activate function"""

--- a/deactivate.py
+++ b/deactivate.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 from activate import deactivate
 """
 Script to deactivate LUFA for Arduino.

--- a/docs/manual_installation.md
+++ b/docs/manual_installation.md
@@ -2,36 +2,49 @@
 
 Manual installation is somewhat tricky, because the stock USB stack is in the arduino core directory instead of a seperated library directory, so you cannot simply drop [Arduino-Lufa] to the library folder under your Sketchbook directory.
 
-    The following setup was last tested with arduino-1.8.3 and LUFA 170418 
+This install will make it so that LUFA can be enabled or disabled by selecting the correct type of board in the `Tools > Board`
+menu of the Arduino IDE.
+
+    The following setup was last tested with arduino-1.8.13 and LUFA 170418 
     (but it should work with future versions, if there were no major changes)
 
-You will neded to modify your arduino installation, so I recommend to create a backup, naming it "arduino-x.x.x_LUFA". (x.x.x. beeing your version number, e.G. 1.8.2)
-
-    You should not use the modified arduino version for non LUFA projects.
-
+    You should not use the Arduino LUFA AVR Boards version for non LUFA projects.
 
 1. clone the repository, drop it in your `arduino-x.x.x_LUFA/libraries` (for instance, you should have `arduino-x.x.x_LUFA/libraries/LUFA/LUFA.h` after this step.
 2. download [LUFA], put everything under `LUFA/` to `arduino-x.x.x_LUFA/libraries/LUFA/LUFA` (for instance, you should have `arduino-x.x.x_LUFA/libraries/LUFA/LUFA/Drivers/USB/USB.h` after this step)
-3. delete the stock USB stack from Arduino environment, there are 7 files to be deleted:
-    1. `arduino-x.x.x_LUFA/hardware/arduino/avr/cores/arduino/CDC.cpp`
-    2. `arduino-x.x.x_LUFA/hardware/arduino/avr/cores/arduino/PluggableUSB.cpp`
-    3. `arduino-x.x.x_LUFA/hardware/arduino/avr/cores/arduino/PluggableUSB.h`
-    4. `arduino-x.x.x_LUFA/hardware/arduino/avr/cores/arduino/USBApi.h`
-    5. `arduino-x.x.x_LUFA/hardware/arduino/avr/cores/arduino/USBCore.cpp`
-    6. `arduino-x.x.x_LUFA/hardware/arduino/avr/cores/arduino/USBCore.h`
-    7. `arduino-x.x.x_LUFA/hardware/arduino/avr/cores/arduino/USBDesc.h`
+3. copy the `arduino-x.x.x_LUFA/hardware/arduino` folder into a new `arduino-x.x.x_LUFA/hardware/arduino-LUFA` folder
+
+3. delete the stock USB stack from Arduino LUFA environment, there are 7 files to be deleted:
+    1. `arduino-x.x.x_LUFA/hardware/arduino-LUFA/avr/cores/arduino/CDC.cpp`
+    2. `arduino-x.x.x_LUFA/hardware/arduino-LUFA/avr/cores/arduino/PluggableUSB.cpp`
+    3. `arduino-x.x.x_LUFA/hardware/arduino-LUFA/avr/cores/arduino/PluggableUSB.h`
+    4. `arduino-x.x.x_LUFA/hardware/arduino-LUFA/avr/cores/arduino/USBApi.h`
+    5. `arduino-x.x.x_LUFA/hardware/arduino-LUFA/avr/cores/arduino/USBCore.cpp`
+    6. `arduino-x.x.x_LUFA/hardware/arduino-LUFA/avr/cores/arduino/USBCore.h`
+    7. `arduino-x.x.x_LUFA/hardware/arduino-LUFA/avr/cores/arduino/USBDesc.h`
+
 4. edit the following files and remove the shown lines:
-    1. `arduino-x.x.x_LUFA/hardware/arduino/avr/cores/arduino/Arduino.h`
+    1. `arduino-x.x.x_LUFA/hardware/arduino-LUFA/avr/cores/arduino/Arduino.h`
         * 233: `#include "USBAPI.h"`
         * 234: `#if defined(HAVE_HWSERIAL0) && defined(HAVE_CDCSERIAL)`
         * 235: `#error "Targets with both UART0 and CDC serial not supported"`
         * 236: `#endif`
-    2. `arduino-x.x.x_LUFA/hardware/arduino/avr/cores/arduino/main.cpp`
+    2. `arduino-x.x.x_LUFA/hardware/arduino-LUFA/avr/cores/arduino/main.cpp`
         * 39: `#if defined(USBCON)`
         * 40: `USBDevice.attach();`
         * 41: `#endif`
 
-That's it! You can now try start the Arduino IDE and compile the examples! :-)
+5. edit the following files and modify the lines accordingly:
+    1. `arduino-x.x.x_LUFA/hardware/arduino-LUFA/avr/platform.txt`
+        * 7: name=Arduino AVR Boards --> name=Arduino LUFA AVR Boards
+    2. (optional) `arduino-x.x.x_LUFA/hardware/arduino-LUFA/avr/boards.txt`
+        Look for "name=" and add "(LUFA)" to the end of each matching line 
+       e.g.
+        * 7: yun.name=Arduino Yún --> yun.name=Arduino Yún (LUFA)
+        * 49: uno.name=Arduino Uno --> uno.name=Arduino Uno (LUFA)
+
+That's it! You can now try start the Arduino IDE and you'll find the `Arduino LUFA AVR Boards` in `Tools > Board` menu.
+You can select one and compile the examples! :-)
 
 [LUFA]:http://www.fourwalledcubicle.com/LUFA.php
 [Arduino-Lufa]:https://github.com/Palatis/Arduino-Lufa

--- a/install.py
+++ b/install.py
@@ -1,0 +1,8 @@
+from activate import install
+"""
+Script to install LUFA boards for Arduino.
+More info can be found in the activate.py script.
+"""
+
+if __name__ == '__main__':
+    install()

--- a/install.py
+++ b/install.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 from activate import install
 """
 Script to install LUFA boards for Arduino.

--- a/uninstall.py
+++ b/uninstall.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 from activate import uninstall
 """
 Script to uninstall LUFA boards for Arduino.

--- a/uninstall.py
+++ b/uninstall.py
@@ -1,0 +1,8 @@
+from activate import uninstall
+"""
+Script to uninstall LUFA boards for Arduino.
+More info can be found in the activate.py script.
+"""
+
+if __name__ == '__main__':
+    uninstall()


### PR DESCRIPTION
I've been using LUFA a lot in various arduino projects, but am still using non-LUFA code as well, and switching was a bit tedious sometimes so I made it so that enabling/disabling LUFA is as easy as selecting the correct board type in the arduino IDE.

I've tested it on windows as well as ubuntu (I've also checked that activate/deactivate still work as intended).

![image](https://user-images.githubusercontent.com/36906596/117702227-85b8fa00-b1c8-11eb-8b4c-a45802dba2c4.png)
